### PR TITLE
ADBDEV-19 Add pxf-api.jar to pxf-service.rpm

### DIFF
--- a/pxf/build.gradle
+++ b/pxf/build.gradle
@@ -288,6 +288,10 @@ project('pxf-service') {
         from(jar.outputs.files) {
             into "/usr/lib/pxf-${project.version}"
         }
+
+        from(project(':pxf-api').jar.outputs.files){
+            into "/usr/lib/pxf-${project.version}"
+        }
         
         //tomcat configuration files
         from('src/configs/tomcat') {


### PR DESCRIPTION
pxf-service.rpm obsoletes pxf-api.rpm since 8b26974c but
pxf-api.jar still needs to be there.