### PR TITLE
Revert "ADBDEV-19 Add pxf-api.jar to pxf-service.rpm"

### DIFF
--- a/pxf/build.gradle
+++ b/pxf/build.gradle
@@ -293,10 +293,6 @@ project('pxf-service') {
         from(jar.outputs.files) {
             into "/usr/lib/pxf-${project.version}"
         }
-
-        from(project(':pxf-api').jar.outputs.files){
-            into "/usr/lib/pxf-${project.version}"
-        }
         
         //tomcat configuration files
         from('src/configs/tomcat') {


### PR DESCRIPTION
This reverts commit 52e264467e5a71fa076fbf2a37d2e1f54a7607ae.

There is no real needs in pxf-api.jar anymore. All troubles
were related to incorrect xml. See commit 39c15d9.