### PR TITLE
ADBDEV-51 & ADBDEV-45

### DIFF
--- a/pxf/pxf-jdbc/src/main/java/org/apache/hawq/pxf/plugins/jdbc/JdbcAccessor.java
+++ b/pxf/pxf-jdbc/src/main/java/org/apache/hawq/pxf/plugins/jdbc/JdbcAccessor.java
@@ -124,7 +124,7 @@ public class JdbcAccessor extends JdbcPlugin implements ReadAccessor, WriteAcces
     @Override
     public boolean openForWrite() throws SQLException, SQLTimeoutException, ParseException, ClassNotFoundException {
         if (statementWrite != null && !statementWrite.isClosed()) {
-            return true;
+            throw new SQLException("The connection to an external database is already open.");
         }
 
         super.openConnection();

--- a/pxf/pxf-jdbc/src/main/java/org/apache/hawq/pxf/plugins/jdbc/JdbcResolver.java
+++ b/pxf/pxf-jdbc/src/main/java/org/apache/hawq/pxf/plugins/jdbc/JdbcResolver.java
@@ -128,11 +128,6 @@ public class JdbcResolver extends JdbcPlugin implements ReadResolver, WriteResol
         int column_index = 0;
         for (OneField oneField : record) {
             ColumnDescriptor column = columns.get(column_index);
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Column #" + (column_index + 1) +
-                ". Name: '" + column.columnName() +
-                "'. Type: '" + DataType.get(column.columnTypeCode()).toString() + "'");
-            }
             if (
                 LOG.isDebugEnabled() &&
                 DataType.get(column.columnTypeCode()) != DataType.get(oneField.type)
@@ -229,7 +224,6 @@ public class JdbcResolver extends JdbcPlugin implements ReadResolver, WriteResol
         }
         return new OneRow(new LinkedList<OneField>(record));
     }
-
 
     private static final Log LOG = LogFactory.getLog(JdbcResolver.class);
 

--- a/pxf/pxf-jdbc/src/main/java/org/apache/hawq/pxf/plugins/jdbc/utils/ByteUtil.java
+++ b/pxf/pxf-jdbc/src/main/java/org/apache/hawq/pxf/plugins/jdbc/utils/ByteUtil.java
@@ -29,17 +29,24 @@ public class ByteUtil {
         return ArrayUtils.addAll(b1,b2);
     }
 
-    public static byte[][] splitBytes(byte[] bytes, int n) {
-        int len = bytes.length / n;
+    /**
+     * Split a byte[] array into two arrays, each of which represents a value of type long
+     */
+    public static byte[][] splitBytes(byte[] bytes) {
+        final int N = 8;
+        int len = bytes.length / N;
         byte[][] newBytes = new byte[len][];
         int j = 0;
         for (int i = 0; i < len; i++) {
-            newBytes[i] = new byte[n];
-            for (int k = 0; k < n; k++) newBytes[i][k] = bytes[j++];
+            newBytes[i] = new byte[N];
+            for (int k = 0; k < N; k++) newBytes[i][k] = bytes[j++];
         }
         return newBytes;
     }
 
+    /**
+     * Convert a value of type long to a byte[] array
+     */
     public static byte[] getBytes(long value) {
         byte[] b = new byte[8];
         b[0] = (byte) ((value >> 56) & 0xFF);
@@ -53,22 +60,9 @@ public class ByteUtil {
         return b;
     }
 
-    public static byte[] getBytes(int value) {
-        byte[] b = new byte[4];
-        b[0] = (byte) ((value >> 24) & 0xFF);
-        b[1] = (byte) ((value >> 16) & 0xFF);
-        b[2] = (byte) ((value >> 8) & 0xFF);
-        b[3] = (byte) ((value >> 0) & 0xFF);
-        return b;
-    }
-
-    public static int toInt(byte[] b) {
-        return (((((int) b[3]) & 0xFF) << 32) +
-                ((((int) b[2]) & 0xFF) << 40) +
-                ((((int) b[1]) & 0xFF) << 48) +
-                ((((int) b[0]) & 0xFF) << 56));
-    }
-
+    /**
+     * Convert a byte[] array to a value of type long
+     */
     public static long toLong(byte[] b) {
         return ((((long) b[7]) & 0xFF) +
                 ((((long) b[6]) & 0xFF) << 8) +

--- a/pxf/pxf-jdbc/src/main/java/org/apache/hawq/pxf/plugins/jdbc/writercallable/BatchWriterCallable.java
+++ b/pxf/pxf-jdbc/src/main/java/org/apache/hawq/pxf/plugins/jdbc/writercallable/BatchWriterCallable.java
@@ -1,0 +1,113 @@
+package org.apache.hawq.pxf.plugins.jdbc.writercallable;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.hawq.pxf.api.OneRow;
+import org.apache.hawq.pxf.plugins.jdbc.JdbcResolver;
+import org.apache.hawq.pxf.plugins.jdbc.JdbcPlugin;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.io.IOException;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+/**
+ * This writer makes batch INSERTs.
+ *
+ * A call() is required after a certain number of supply() calls
+ */
+class BatchWriterCallable implements WriterCallable {
+    @Override
+    public void supply(OneRow row) throws IllegalStateException {
+        if ((maxRowsCount > 0) && (rows.size() >= maxRowsCount)) {
+            throw new IllegalStateException("Trying to supply() a OneRow object to a full WriterCallable");
+        }
+        if (row == null) {
+            throw new IllegalArgumentException("Trying to supply() a null OneRow object");
+        }
+        rows.add(row);
+    }
+
+    @Override
+    public boolean isCallRequired() {
+        if ((maxRowsCount > 0) && (rows.size() >= maxRowsCount)) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public SQLException call() throws IOException, SQLException, ClassNotFoundException {
+        if (rows.isEmpty()) {
+            return null;
+        }
+
+        boolean statementMustBeDeleted = false;
+        if (statement == null) {
+            statement = plugin.getPreparedStatement(plugin.getConnection(), query);
+            statementMustBeDeleted = true;
+        }
+
+        for (OneRow row : rows) {
+            JdbcResolver.decodeOneRowToPreparedStatement(row, statement);
+            statement.addBatch();
+        }
+
+        try {
+            statement.executeBatch();
+        }
+        catch (SQLException e) {
+            return e;
+        }
+        finally {
+            rows.clear();
+            if (statementMustBeDeleted) {
+                JdbcPlugin.closeStatement(statement);
+                statement = null;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Construct a new batch writer
+     */
+    BatchWriterCallable(JdbcPlugin plugin, String query, PreparedStatement statement, int maxRowsCount) throws IllegalArgumentException {
+        if ((plugin == null) || (query == null)) {
+            throw new IllegalArgumentException("The provided JdbcPlugin or SQL query is null");
+        }
+        this.plugin = plugin;
+        this.query = query;
+        this.statement = statement;
+        if (maxRowsCount < 0) {
+            maxRowsCount = 0;
+        }
+        this.maxRowsCount = maxRowsCount;
+        rows = new LinkedList<>();
+    }
+
+    private final JdbcPlugin plugin;
+    private final String query;
+    private PreparedStatement statement;
+    private List<OneRow> rows;
+    private final int maxRowsCount;
+}

--- a/pxf/pxf-jdbc/src/main/java/org/apache/hawq/pxf/plugins/jdbc/writercallable/SimpleWriterCallable.java
+++ b/pxf/pxf-jdbc/src/main/java/org/apache/hawq/pxf/plugins/jdbc/writercallable/SimpleWriterCallable.java
@@ -1,0 +1,105 @@
+package org.apache.hawq.pxf.plugins.jdbc.writercallable;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.hawq.pxf.api.OneRow;
+import org.apache.hawq.pxf.plugins.jdbc.JdbcResolver;
+import org.apache.hawq.pxf.plugins.jdbc.JdbcPlugin;
+
+import java.io.IOException;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+/**
+ * This writer makes simple, one-by-one INSERTs.
+ *
+ * A call() is required after every supply()
+ */
+class SimpleWriterCallable implements WriterCallable {
+    @Override
+    public void supply(OneRow row) throws IllegalStateException, IllegalArgumentException {
+        if (this.row != null) {
+            throw new IllegalStateException("Trying to supply() a OneRow object to a full WriterCallable");
+        }
+        if (row == null) {
+            throw new IllegalArgumentException("Trying to supply() a null OneRow object");
+        }
+        this.row = row;
+    }
+
+    @Override
+    public boolean isCallRequired() {
+        if (this.row != null) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public SQLException call() throws IOException, SQLException, ClassNotFoundException {
+        if (row == null) {
+            return null;
+        }
+
+        boolean statementMustBeDeleted = false;
+        if (statement == null) {
+            statement = plugin.getPreparedStatement(plugin.getConnection(), query);
+            statementMustBeDeleted = true;
+        }
+
+        JdbcResolver.decodeOneRowToPreparedStatement(row, statement);
+
+        try {
+            if (statement.executeUpdate() != 1) {
+                throw new SQLException("The number of rows affected by INSERT query is not equal to the number of rows provided");
+            }
+        }
+        catch (SQLException e) {
+            return e;
+        }
+        finally {
+            row = null;
+            if (statementMustBeDeleted) {
+                JdbcPlugin.closeStatement(statement);
+                statement = null;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Construct a new simple writer
+     */
+    SimpleWriterCallable(JdbcPlugin plugin, String query, PreparedStatement statement) throws IllegalArgumentException {
+        if ((plugin == null) || (query == null)) {
+            throw new IllegalArgumentException("The provided JdbcPlugin or SQL query is null");
+        }
+        this.plugin = plugin;
+        this.query = query;
+        this.statement = statement;
+        row = null;
+    }
+
+    private final JdbcPlugin plugin;
+    private final String query;
+    private PreparedStatement statement;
+    private OneRow row;
+}

--- a/pxf/pxf-jdbc/src/main/java/org/apache/hawq/pxf/plugins/jdbc/writercallable/WriterCallable.java
+++ b/pxf/pxf-jdbc/src/main/java/org/apache/hawq/pxf/plugins/jdbc/writercallable/WriterCallable.java
@@ -1,0 +1,57 @@
+package org.apache.hawq.pxf.plugins.jdbc.writercallable;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.hawq.pxf.api.OneRow;
+
+import java.util.concurrent.Callable;
+import java.sql.SQLException;
+
+/**
+ * An object that processes INSERT operation on {@link OneRow} objects
+ */
+public interface WriterCallable extends Callable<SQLException> {
+    /**
+     * Pass the next OneRow to this WriterCallable.
+     *
+     * @throws IllegalStateException if this WriterCallable must be call()ed before the next call to supply()
+     * @throws IllegalArgumentException if row is null
+     */
+    void supply(OneRow row) throws IllegalStateException, IllegalArgumentException;
+
+    /**
+     * Check whether this WriterCallable must be called
+     *
+     * @return true if this WriterCallable must be call()ed before the next call to supply()
+     * @return false otherwise
+     */
+    boolean isCallRequired();
+
+    /**
+     * Execute an INSERT query.
+     *
+     * @return null or a SQLException that happened when executing the query
+     * @return null if the query was empty (nothing was there to execute)
+     *
+     * @throws Exception an exception that happened during execution, but that is not related to the execution of the query itself (for instance, it may originate from {@link java.sql.PreparedStatement} close() method)
+     */
+    @Override
+    SQLException call() throws Exception;
+}

--- a/pxf/pxf-jdbc/src/main/java/org/apache/hawq/pxf/plugins/jdbc/writercallable/WriterCallableFactory.java
+++ b/pxf/pxf-jdbc/src/main/java/org/apache/hawq/pxf/plugins/jdbc/writercallable/WriterCallableFactory.java
@@ -1,0 +1,108 @@
+package org.apache.hawq.pxf.plugins.jdbc.writercallable;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.hawq.pxf.api.OneRow;
+import org.apache.hawq.pxf.plugins.jdbc.JdbcPlugin;
+
+import java.sql.PreparedStatement;
+
+/**
+ * An object that processes INSERT operation on {@link OneRow} objects
+ */
+public class WriterCallableFactory {
+    /**
+     * Create a new factory.
+     *
+     * Note that before constructing {@link WriterCallable}, 'setBatchSize' and 'setStatement' must be called.
+     *
+     * By default, 'batchSize' is 1 and 'statement' is null
+     */
+    public WriterCallableFactory() {
+        batchSize = 1;
+        plugin = null;
+        query = null;
+        statement = null;
+    }
+
+    /**
+     * Get an instance of WriterCallable
+     *
+     * @return an implementation of WriterCallable, chosen based on parameters that were set for this factory
+     * @throws IllegalArgumentException if a WriterCallable cannot be created with requested parameters
+     */
+    public WriterCallable get() throws IllegalArgumentException {
+        if (batchSize == 1) {
+            return new SimpleWriterCallable(plugin, query, statement);
+        }
+        else {
+            return new BatchWriterCallable(plugin, query, statement, batchSize);
+        }
+    }
+
+    /**
+     * Set {@link JdbcPlugin} to use.
+     * REQUIRED
+     */
+    public void setPlugin(JdbcPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    /**
+     * Set SQL query to use.
+     * REQUIRED
+     */
+    public void setQuery(String query) {
+        this.query = query;
+    }
+
+    /**
+     * Set batch size to use.
+     *
+     * @param batchSize < 0: Use batches of infinite size
+     * @param batchSize = 1: Do not use batches
+     * @param batchSize > 1: Use batches of the given size
+     */
+    public void setBatchSize(int batchSize) {
+        if (batchSize < 0) {
+            batchSize = 0;
+        }
+        else if (batchSize == 0) {
+            batchSize = 1;
+        }
+        this.batchSize = batchSize;
+    }
+
+    /**
+     * Set statement to use.
+     *
+     * @param statement = null: Create a new connection & a new statement each time {@link WriterCallable} is called
+     * @param statement not null: Use the given statement and do not close or reopen it
+     */
+    public void setStatement(PreparedStatement statement) {
+        this.statement = statement;
+    }
+
+
+    private int batchSize;
+    private JdbcPlugin plugin;
+    private String query;
+    private PreparedStatement statement;
+}

--- a/pxf/pxf-jdbc/src/test/java/org/apache/hawq/pxf/plugins/jdbc/JdbcPartitionFragmenterTest.java
+++ b/pxf/pxf-jdbc/src/test/java/org/apache/hawq/pxf/plugins/jdbc/JdbcPartitionFragmenterTest.java
@@ -56,7 +56,7 @@ public class JdbcPartitionFragmenterTest {
 
         //fragment - 1
         byte[] fragMeta = fragments.get(0).getMetadata();
-        byte[][] newBytes = ByteUtil.splitBytes(fragMeta, 8);
+        byte[][] newBytes = ByteUtil.splitBytes(fragMeta);
         long fragStart = ByteUtil.toLong(newBytes[0]);
         long fragEnd = ByteUtil.toLong(newBytes[1]);
         assertDateEquals(fragStart, 2008, 1, 1);
@@ -64,7 +64,7 @@ public class JdbcPartitionFragmenterTest {
 
         //fragment - 12
         fragMeta = fragments.get(11).getMetadata();
-        newBytes = ByteUtil.splitBytes(fragMeta, 8);
+        newBytes = ByteUtil.splitBytes(fragMeta);
         fragStart = ByteUtil.toLong(newBytes[0]);
         fragEnd = ByteUtil.toLong(newBytes[1]);
         assertDateEquals(fragStart, 2008, 12, 1);
@@ -102,17 +102,17 @@ public class JdbcPartitionFragmenterTest {
 
         //fragment - 1
         byte[] fragMeta = fragments.get(0).getMetadata();
-        byte[][] newBytes = ByteUtil.splitBytes(fragMeta, 4);
-        int fragStart = ByteUtil.toInt(newBytes[0]);
-        int fragEnd = ByteUtil.toInt(newBytes[1]);
+        byte[][] newBytes = ByteUtil.splitBytes(fragMeta);
+        long fragStart = ByteUtil.toLong(newBytes[0]);
+        long fragEnd = ByteUtil.toLong(newBytes[1]);
         assertEquals(2001, fragStart);
         assertEquals(2003, fragEnd);
 
         //fragment - 6
         fragMeta = fragments.get(5).getMetadata();
-        newBytes = ByteUtil.splitBytes(fragMeta, 4);
-        fragStart = ByteUtil.toInt(newBytes[0]);
-        fragEnd = ByteUtil.toInt(newBytes[1]);
+        newBytes = ByteUtil.splitBytes(fragMeta);
+        fragStart = ByteUtil.toLong(newBytes[0]);
+        fragEnd = ByteUtil.toLong(newBytes[1]);
         assertEquals(2011, fragStart);
         assertEquals(2012, fragEnd);
 


### PR DESCRIPTION
## ADBDEV-45
Implement thread pool support for INSERT queries. See https://github.com/arenadata/incubator-hawq/commit/30defc7d80857d2ab79cd814abe5c07acdf48969 for the detailed description and [the updated README](https://github.com/arenadata/incubator-hawq/blob/30defc7d80857d2ab79cd814abe5c07acdf48969/pxf/pxf-jdbc/README.md) for instructions for user.

This PR also ports a few minor fixes proposed in the PR to upstream.

## ADBDEV-51
Add support of values of Java primitive type `long` to be used in `PARTITION_BY` clause (both for `RANGE` and `INTERVAL` variables).


### P.S.
Sorry for combining two tasks into one PR