### PR TITLE
AS-600709

### DIFF
--- a/pxf/pxf-hive/src/main/java/org/apache/hawq/pxf/plugins/hive/HiveDataFragmenter.java
+++ b/pxf/pxf-hive/src/main/java/org/apache/hawq/pxf/plugins/hive/HiveDataFragmenter.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.TextInputFormat;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hawq.pxf.api.BasicFilter;
 import org.apache.hawq.pxf.api.FilterParser;
 import org.apache.hawq.pxf.api.Fragment;
@@ -164,6 +165,9 @@ public class HiveDataFragmenter extends Fragmenter {
      * InputFormat and Serde per split.
      */
     private void fetchTableMetaData(Metadata.Item tblDesc) throws Exception {
+        if (HiveUtilities.isKerberosAuthEnabled()) {
+            UserGroupInformation.getLoginUser().checkTGTAndReloginFromKeytab();
+        }
 
         Table tbl = HiveUtilities.getHiveTable(client, tblDesc);
 
@@ -427,9 +431,9 @@ public class HiveDataFragmenter extends Fragmenter {
             return false;
         }
 
-        /* 
-         * HAWQ-1527 - Filtering only supported for partition columns of type string or 
-         * intgeral datatype. Integral datatypes include - TINYINT, SMALLINT, INT, BIGINT. 
+        /*
+         * HAWQ-1527 - Filtering only supported for partition columns of type string or
+         * intgeral datatype. Integral datatypes include - TINYINT, SMALLINT, INT, BIGINT.
          * Note that with integral data types only equals("=") and not equals("!=") operators
          * are supported. There are no operator restrictions with String.
          */

--- a/pxf/pxf-hive/src/main/java/org/apache/hawq/pxf/plugins/hive/HiveMetadataFetcher.java
+++ b/pxf/pxf-hive/src/main/java/org/apache/hawq/pxf/plugins/hive/HiveMetadataFetcher.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hawq.pxf.api.Metadata;
 import org.apache.hawq.pxf.api.MetadataFetcher;
@@ -79,6 +80,9 @@ public class HiveMetadataFetcher extends MetadataFetcher {
      */
     @Override
     public List<Metadata> getMetadata(String pattern) throws Exception {
+        if (HiveUtilities.isKerberosAuthEnabled()) {
+            UserGroupInformation.getLoginUser().checkTGTAndReloginFromKeytab();
+        }
 
         boolean ignoreErrors = false;
         List<Metadata.Item> tblsDesc = HiveUtilities.extractTablesFromPattern(client, pattern);

--- a/pxf/pxf-hive/src/main/java/org/apache/hawq/pxf/plugins/hive/utilities/HiveUtilities.java
+++ b/pxf/pxf-hive/src/main/java/org/apache/hawq/pxf/plugins/hive/utilities/HiveUtilities.java
@@ -163,6 +163,12 @@ public class HiveUtilities {
      */
     public static HiveMetaStoreClient initHiveClient(HiveConf conf) {
         HiveMetaStoreClient client = null;
+        String principal = conf.get("hive.server2.authentication.kerberos.principal").replace("/_HOST", "");
+        HiveUtilities.authenticate(
+            conf,
+            principal,
+            conf.get("hive.server2.authentication.kerberos.keytab")
+        );
         try {
             client = new HiveMetaStoreClient(conf);
         } catch (MetaException cause) {

--- a/pxf/pxf-hive/src/main/java/org/apache/hawq/pxf/plugins/hive/utilities/HiveUtilities.java
+++ b/pxf/pxf-hive/src/main/java/org/apache/hawq/pxf/plugins/hive/utilities/HiveUtilities.java
@@ -136,12 +136,13 @@ public class HiveUtilities {
         try {
             HiveConf config = hiveConf != null ? hiveConf : new HiveConf();
             final String auth = config.get("hadoop.security.authentication");
-            if (auth != null && auth.equals("kerberos")) {
+            if (auth != null && auth.toLowerCase().equals("kerberos")) {
+                LOG.debug("Kerberos authentication for Hive is enabled");
                 return true;
             }
         }
         catch (Exception ex) {
-            LOG.debug("An exception happened when checking Kerberos auth: " + ex.toString());
+            LOG.debug("An exception happened when checking Kerberos authentication for Hive: " + ex.toString());
         }
         return false;
     }
@@ -154,6 +155,7 @@ public class HiveUtilities {
     private static synchronized void authenticate() {
         if (hiveConf == null && isKerberosAuthEnabled()) {
             // Kerberos authentication is required
+            LOG.debug("Start Kerberos authentication for Hive");
             HiveConf config = new HiveConf(HiveMetaStoreClient.class);
 
             if (System.getProperty(CONFIG_KEY_KERBEROS_CONF) == null) {
@@ -181,6 +183,7 @@ public class HiveUtilities {
             }
 
             hiveConf = config;
+            LOG.debug("Kerberos authentication for Hive successful");
         }
     }
 


### PR DESCRIPTION
Add support for Kerberos authentication to PXF-Hive plugin.

`authenticate()` in `HiveUtilities` provides an interface to handle authentication. It also prevents repeated authentication attempts (`MetadataFetcher` is not the only place that requires authentication; it is also required by `HiveDataFragmenter`).