### PR TITLE
ADBDEV-118. Add double quotes to column names

### DIFF
--- a/pxf/pxf-api/src/main/java/org/apache/hawq/pxf/api/utilities/ColumnDescriptor.java
+++ b/pxf/pxf-api/src/main/java/org/apache/hawq/pxf/api/utilities/ColumnDescriptor.java
@@ -8,9 +8,9 @@ package org.apache.hawq.pxf.api.utilities;
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -85,6 +85,10 @@ public class ColumnDescriptor {
 
     public String columnName() {
         return dbColumnName;
+    }
+
+    public void setColumnName(String columnName) {
+        dbColumnName = columnName;
     }
 
     public int columnTypeCode() {

--- a/pxf/pxf-api/src/test/java/org/apache/hawq/pxf/api/utilities/ColumnDescriptorTest.java
+++ b/pxf/pxf-api/src/test/java/org/apache/hawq/pxf/api/utilities/ColumnDescriptorTest.java
@@ -20,14 +20,13 @@ package org.apache.hawq.pxf.api.utilities;
  */
 
 import org.apache.hawq.pxf.api.utilities.ColumnDescriptor;
+
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import org.junit.Test;
 
 public class ColumnDescriptorTest {
-
-
     @Test
     public void testConstructor() {
 
@@ -42,10 +41,9 @@ public class ColumnDescriptorTest {
         assertArrayEquals(clonned.columnTypeModifiers(), cd.columnTypeModifiers());
         assertEquals(clonned.isKeyColumn(), cd.isKeyColumn());
 
-        //Cloned instance should have reference to different array
+        // Clonned instance should have reference to different array
         assertFalse(clonned.columnTypeModifiers() == cd.columnTypeModifiers());
 
         cd = new ColumnDescriptor(null, 0, 0, null, null);
     }
-
 }

--- a/pxf/pxf-jdbc/src/main/java/org/apache/hawq/pxf/plugins/jdbc/JdbcPlugin.java
+++ b/pxf/pxf-jdbc/src/main/java/org/apache/hawq/pxf/plugins/jdbc/JdbcPlugin.java
@@ -112,6 +112,9 @@ public class JdbcPlugin extends Plugin {
             }
         }
 
+        // This parameter is not required. The default value is false
+        quoteColumns = (inputData.getUserProperty("QUOTE_COLUMNS") != null);
+
         // This parameter is not required. The default value is null
         preQuerySql = input.getUserProperty("PRE_SQL");
         if (preQuerySql != null) {
@@ -213,6 +216,7 @@ public class JdbcPlugin extends Plugin {
     // User-defined parameters for all queries
     protected String preQuerySql = null;
     protected boolean stopIfPreQueryFails = false;
+    protected boolean quoteColumns = false;
 
     // User-defined parameters for INSERT queries
     protected int batchSize = 0;

--- a/pxf/pxf-jdbc/src/main/java/org/apache/hawq/pxf/plugins/jdbc/utils/DbProduct.java
+++ b/pxf/pxf-jdbc/src/main/java/org/apache/hawq/pxf/plugins/jdbc/utils/DbProduct.java
@@ -19,11 +19,19 @@ package org.apache.hawq.pxf.plugins.jdbc.utils;
  * under the License.
  */
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 /**
- * A tool class to process data types that must have different form in different databases.
- * Such processing is required to create correct constraints (WHERE statements).
+ * A tool class to change PXF behaviour for some external databases.
+ *
+ * To implement new DbProduct:
+ * 1. Create a class inheriting from this one and implement logic there;
+ * 2. Add new class constructor to getDbProduct() function.
  */
 public abstract class DbProduct {
+    private static final Log LOG = LogFactory.getLog(DbProduct.class);
+
     /**
      * Get an instance of some class - the database product
      *
@@ -31,20 +39,23 @@ public abstract class DbProduct {
      * @return a DbProduct of the required class
      */
     public static DbProduct getDbProduct(String dbName) {
-        if (dbName.toUpperCase().contains("MYSQL"))
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Database product name is '" + dbName + "'");
+        }
+        if (dbName.toUpperCase().contains("POSTGRES"))
+            return new PostgresProduct();
+        else if (dbName.toUpperCase().contains("MYSQL"))
             return new MysqlProduct();
         else if (dbName.toUpperCase().contains("ORACLE"))
             return new OracleProduct();
-        else if (dbName.toUpperCase().contains("POSTGRES"))
-            return new PostgresProduct();
         else if (dbName.toUpperCase().contains("MICROSOFT"))
             return new MicrosoftProduct();
         else
-            return new CommonProduct();
+            return new PostgresProduct();
     }
 
     /**
-     * Wraps a given date value the way required by a target database
+     * Wraps a given date value the way required by target database
      *
      * @param val {@link java.sql.Date} object to wrap
      * @return a string with a properly wrapped date object
@@ -52,25 +63,10 @@ public abstract class DbProduct {
     public abstract String wrapDate(Object val);
 
     /**
-     * Wraps a given timestamp value the way required by a target database
+     * Wraps a given timestamp value the way required by target database
      *
      * @param val {@link java.sql.Timestamp} object to wrap
      * @return a string with a properly wrapped timestamp object
      */
     public abstract String wrapTimestamp(Object val);
-}
-
-/**
- * Common product. Used when no other products are avalibale
- */
-class CommonProduct extends DbProduct {
-    @Override
-    public String wrapDate(Object val) {
-        return "date'" + val + "'";
-    }
-
-    @Override
-    public String wrapTimestamp(Object val) {
-        return "'" + val + "'";
-    }
 }

--- a/pxf/pxf-jdbc/src/main/java/org/apache/hawq/pxf/plugins/jdbc/utils/MicrosoftProduct.java
+++ b/pxf/pxf-jdbc/src/main/java/org/apache/hawq/pxf/plugins/jdbc/utils/MicrosoftProduct.java
@@ -22,14 +22,9 @@ package org.apache.hawq.pxf.plugins.jdbc.utils;
 /**
  * Implements methods for the Microsoft SQL server database
  */
-public class MicrosoftProduct extends DbProduct {
+public class MicrosoftProduct extends PostgresProduct {
     @Override
     public String wrapDate(Object val){
-        return "'" + val + "'";
-    }
-
-    @Override
-    public String wrapTimestamp(Object val) {
         return "'" + val + "'";
     }
 }

--- a/pxf/pxf-jdbc/src/main/java/org/apache/hawq/pxf/plugins/jdbc/utils/MysqlProduct.java
+++ b/pxf/pxf-jdbc/src/main/java/org/apache/hawq/pxf/plugins/jdbc/utils/MysqlProduct.java
@@ -22,14 +22,9 @@ package org.apache.hawq.pxf.plugins.jdbc.utils;
 /**
  * Implements methods for the MySQL Database.
  */
-public class MysqlProduct extends DbProduct {
+public class MysqlProduct extends PostgresProduct {
     @Override
     public String wrapDate(Object val){
         return "DATE('" + val + "')";
-    }
-
-    @Override
-    public String wrapTimestamp(Object val) {
-        return "'" + val + "'";
     }
 }

--- a/pxf/pxf-jdbc/src/main/java/org/apache/hawq/pxf/plugins/jdbc/utils/PostgresProduct.java
+++ b/pxf/pxf-jdbc/src/main/java/org/apache/hawq/pxf/plugins/jdbc/utils/PostgresProduct.java
@@ -20,7 +20,8 @@ package org.apache.hawq.pxf.plugins.jdbc.utils;
  */
 
 /**
- * Implements methods for the PostgreSQL.
+ * Implements methods for the PostgreSQL, and is also used
+ * when no other product is avalibale.
  */
 public class PostgresProduct extends DbProduct {
     @Override

--- a/pxf/pxf-jdbc/src/test/java/org/apache/hawq/pxf/plugins/jdbc/DbProductTest.java
+++ b/pxf/pxf-jdbc/src/test/java/org/apache/hawq/pxf/plugins/jdbc/DbProductTest.java
@@ -1,0 +1,140 @@
+package org.apache.hawq.pxf.plugins.jdbc;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.hawq.pxf.plugins.jdbc.utils.DbProduct;
+import org.apache.hawq.pxf.plugins.jdbc.utils.PostgresProduct;
+
+import java.sql.Timestamp;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.sql.Date;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class DbProductTest {
+    private static final Date[] DATES = new Date[1];
+    private static final Timestamp[] TIMESTAMPS = new Timestamp[1];
+    static {
+        try {
+            DATES[0] = new Date(
+                new SimpleDateFormat("yyyy-MM-dd").parse("2001-01-01 00:00:00").getTime()
+            );
+            TIMESTAMPS[0] = new Timestamp(
+                new SimpleDateFormat("yyyy-MM-dd").parse("2001-01-01 00:00:00").getTime()
+            );
+        }
+        catch (ParseException e) {
+            DATES[0] = null;
+            TIMESTAMPS[0] = null;
+        }
+    }
+
+
+    private static final String DB_NAME_UNKNOWN = "no such database";
+
+    @Test
+    public void testUnknownProductIsPostgresProduct() {
+        assertTrue(DbProduct.getDbProduct(DB_NAME_UNKNOWN) instanceof PostgresProduct);
+    }
+
+    /*
+     * This test also applies to Postgres database
+     */
+    @Test
+    public void testUnknownDates() {
+        final String[] EXPECTED = {"date'2001-01-01'"};
+
+        DbProduct dbProduct = DbProduct.getDbProduct(DB_NAME_UNKNOWN);
+
+        for (int i = 0; i < DATES.length; i++) {
+            assertEquals(EXPECTED[i], dbProduct.wrapDate(DATES[i]));
+        }
+    }
+
+    /*
+     * This test also applies to Postgres database
+     */
+    @Test
+    public void testUnknownTimestamps() {
+        final String[] EXPECTED = {"'2001-01-01 00:00:00.0'"};
+
+        DbProduct dbProduct = DbProduct.getDbProduct(DB_NAME_UNKNOWN);
+
+        for (int i = 0; i < TIMESTAMPS.length; i++) {
+            assertEquals(EXPECTED[i], dbProduct.wrapTimestamp(TIMESTAMPS[i]));
+        }
+    }
+
+
+    private static final String DB_NAME_ORACLE = "ORACLE";
+
+    @Test
+    public void testOracleDates() {
+        final String[] EXPECTED = {"to_date('2001-01-01', 'YYYY-MM-DD')"};
+
+        DbProduct dbProduct = DbProduct.getDbProduct(DB_NAME_ORACLE);
+
+        for (int i = 0; i < DATES.length; i++) {
+            assertEquals(EXPECTED[i], dbProduct.wrapDate(DATES[i]));
+        }
+    }
+
+    @Test
+    public void testOracleTimestamps() {
+        final String[] EXPECTED = {"to_timestamp('2001-01-01 00:00:00.0', 'YYYY-MM-DD HH:MI:SS.FF')"};
+
+        DbProduct dbProduct = DbProduct.getDbProduct(DB_NAME_ORACLE);
+
+        for (int i = 0; i < TIMESTAMPS.length; i++) {
+            assertEquals(EXPECTED[i], dbProduct.wrapTimestamp(TIMESTAMPS[i]));
+        }
+    }
+
+
+    private static final String DB_NAME_MICROSOFT = "MICROSOFT";
+
+    @Test
+    public void testMicrosoftDates() {
+        final String[] EXPECTED = {"'2001-01-01'"};
+
+        DbProduct dbProduct = DbProduct.getDbProduct(DB_NAME_MICROSOFT);
+
+        for (int i = 0; i < DATES.length; i++) {
+            assertEquals(EXPECTED[i], dbProduct.wrapDate(DATES[i]));
+        }
+    }
+
+
+    private static final String DB_NAME_MYSQL = "MYSQL";
+
+    @Test
+    public void testMySQLDates() {
+        final String[] EXPECTED = {"DATE('2001-01-01')"};
+
+        DbProduct dbProduct = DbProduct.getDbProduct(DB_NAME_MYSQL);
+
+        for (int i = 0; i < DATES.length; i++) {
+            assertEquals(EXPECTED[i], dbProduct.wrapDate(DATES[i]));
+        }
+    }
+}


### PR DESCRIPTION
## PXF-JDBC connector update

* Add double quotes to column names in external connections when user asks for that
* Add tests for DbProduct
* Update README.md