### PR TITLE
AS-600709

### DIFF
--- a/pxf/pxf-hive/src/main/java/org/apache/hawq/pxf/plugins/hive/HiveDataFragmenter.java
+++ b/pxf/pxf-hive/src/main/java/org/apache/hawq/pxf/plugins/hive/HiveDataFragmenter.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.TextInputFormat;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hawq.pxf.api.BasicFilter;
 import org.apache.hawq.pxf.api.FilterParser;
 import org.apache.hawq.pxf.api.Fragment;
@@ -164,6 +165,9 @@ public class HiveDataFragmenter extends Fragmenter {
      * InputFormat and Serde per split.
      */
     private void fetchTableMetaData(Metadata.Item tblDesc) throws Exception {
+        if (HiveUtilities.isKerberosAuthEnabled()) {
+            UserGroupInformation.getLoginUser().checkTGTAndReloginFromKeytab();
+        }
 
         Table tbl = HiveUtilities.getHiveTable(client, tblDesc);
 
@@ -427,9 +431,9 @@ public class HiveDataFragmenter extends Fragmenter {
             return false;
         }
 
-        /* 
-         * HAWQ-1527 - Filtering only supported for partition columns of type string or 
-         * intgeral datatype. Integral datatypes include - TINYINT, SMALLINT, INT, BIGINT. 
+        /*
+         * HAWQ-1527 - Filtering only supported for partition columns of type string or
+         * intgeral datatype. Integral datatypes include - TINYINT, SMALLINT, INT, BIGINT.
          * Note that with integral data types only equals("=") and not equals("!=") operators
          * are supported. There are no operator restrictions with String.
          */

--- a/pxf/pxf-hive/src/main/java/org/apache/hawq/pxf/plugins/hive/HiveMetadataFetcher.java
+++ b/pxf/pxf-hive/src/main/java/org/apache/hawq/pxf/plugins/hive/HiveMetadataFetcher.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hawq.pxf.api.Metadata;
 import org.apache.hawq.pxf.api.MetadataFetcher;
@@ -79,6 +80,9 @@ public class HiveMetadataFetcher extends MetadataFetcher {
      */
     @Override
     public List<Metadata> getMetadata(String pattern) throws Exception {
+        if (HiveUtilities.isKerberosAuthEnabled()) {
+            UserGroupInformation.getLoginUser().checkTGTAndReloginFromKeytab();
+        }
 
         boolean ignoreErrors = false;
         List<Metadata.Item> tblsDesc = HiveUtilities.extractTablesFromPattern(client, pattern);

--- a/pxf/pxf-hive/src/main/java/org/apache/hawq/pxf/plugins/hive/utilities/HiveUtilities.java
+++ b/pxf/pxf-hive/src/main/java/org/apache/hawq/pxf/plugins/hive/utilities/HiveUtilities.java
@@ -163,6 +163,12 @@ public class HiveUtilities {
      */
     public static HiveMetaStoreClient initHiveClient(HiveConf conf) {
         HiveMetaStoreClient client = null;
+        String principal = conf.get("hive.server2.authentication.kerberos.principal").replace("/_HOST", "");
+        HiveUtilities.authenticate(
+            conf,
+            principal,
+            conf.get("hive.server2.authentication.kerberos.keytab")
+        );
         try {
             client = new HiveMetaStoreClient(conf);
         } catch (MetaException cause) {

--- a/pxf/pxf-hive/src/main/java/org/apache/hawq/pxf/plugins/hive/utilities/HiveUtilities.java
+++ b/pxf/pxf-hive/src/main/java/org/apache/hawq/pxf/plugins/hive/utilities/HiveUtilities.java
@@ -136,12 +136,13 @@ public class HiveUtilities {
         try {
             HiveConf config = hiveConf != null ? hiveConf : new HiveConf();
             final String auth = config.get("hadoop.security.authentication");
-            if (auth != null && auth.equals("kerberos")) {
+            if (auth != null && auth.toLowerCase().equals("kerberos")) {
+                LOG.debug("Kerberos authentication for Hive is enabled");
                 return true;
             }
         }
         catch (Exception ex) {
-            LOG.debug("An exception happened when checking Kerberos auth: " + ex.toString());
+            LOG.debug("An exception happened when checking Kerberos authentication for Hive: " + ex.toString());
         }
         return false;
     }
@@ -154,6 +155,7 @@ public class HiveUtilities {
     private static synchronized void authenticate() {
         if (hiveConf == null && isKerberosAuthEnabled()) {
             // Kerberos authentication is required
+            LOG.debug("Start Kerberos authentication for Hive");
             HiveConf config = new HiveConf(HiveMetaStoreClient.class);
 
             if (System.getProperty(CONFIG_KEY_KERBEROS_CONF) == null) {
@@ -181,6 +183,7 @@ public class HiveUtilities {
             }
 
             hiveConf = config;
+            LOG.debug("Kerberos authentication for Hive successful");
         }
     }
 

--- a/pxf/pxf-hive/src/test/java/org/apache/hawq/pxf/plugins/hive/HiveDataFragmenterTest.java
+++ b/pxf/pxf-hive/src/test/java/org/apache/hawq/pxf/plugins/hive/HiveDataFragmenterTest.java
@@ -8,9 +8,9 @@ package org.apache.hawq.pxf.plugins.hive;
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -49,7 +49,7 @@ import java.util.*;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({HiveDataFragmenter.class}) // Enables mocking 'new' calls
-@SuppressStaticInitializationFor({"org.apache.hadoop.mapred.JobConf", 
+@SuppressStaticInitializationFor({"org.apache.hadoop.mapred.JobConf",
                                   "org.apache.hadoop.hive.metastore.api.MetaException",
                                   "org.apache.hawq.pxf.plugins.hive.utilities.HiveUtilities"}) // Prevents static inits
 public class HiveDataFragmenterTest {
@@ -316,7 +316,7 @@ public class HiveDataFragmenterTest {
         PowerMockito.whenNew(JobConf.class).withArguments(hadoopConfiguration, HiveDataFragmenter.class).thenReturn(jobConf);
 
         hiveConfiguration = mock(HiveConf.class);
-        PowerMockito.whenNew(HiveConf.class).withNoArguments().thenReturn(hiveConfiguration);
+        PowerMockito.whenNew(HiveConf.class).withAnyArguments().thenReturn(hiveConfiguration);
 
         hiveClient = mock(HiveMetaStoreClient.class);
         PowerMockito.whenNew(HiveMetaStoreClient.class).withArguments(hiveConfiguration).thenReturn(hiveClient);

--- a/pxf/pxf-hive/src/test/java/org/apache/hawq/pxf/plugins/hive/HiveMetadataFetcherTest.java
+++ b/pxf/pxf-hive/src/test/java/org/apache/hawq/pxf/plugins/hive/HiveMetadataFetcherTest.java
@@ -8,9 +8,9 @@ package org.apache.hawq.pxf.plugins.hive;
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -95,7 +95,7 @@ public class HiveMetadataFetcherTest {
             fetcher.getMetadata(tableName);
             fail("Expected an IllegalArgumentException");
         } catch (IllegalArgumentException ex) {
-            assertEquals("\"t.r.o.u.b.l.e.m.a.k.e.r\" is not a valid Hive table name. Should be either <table_name> or <db_name.table_name>", ex.getMessage()); 
+            assertEquals("\"t.r.o.u.b.l.e.m.a.k.e.r\" is not a valid Hive table name. Should be either <table_name> or <db_name.table_name>", ex.getMessage());
         }
     }
 
@@ -269,7 +269,7 @@ public class HiveMetadataFetcherTest {
 
     private void prepareConstruction() throws Exception {
         hiveConfiguration = mock(HiveConf.class);
-        PowerMockito.whenNew(HiveConf.class).withNoArguments().thenReturn(hiveConfiguration);
+        PowerMockito.whenNew(HiveConf.class).withAnyArguments().thenReturn(hiveConfiguration);
 
         hiveClient = mock(HiveMetaStoreClient.class);
         PowerMockito.whenNew(HiveMetaStoreClient.class).withArguments(hiveConfiguration).thenReturn(hiveClient);

--- a/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/utilities/SecureLogin.java
+++ b/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/utilities/SecureLogin.java
@@ -19,13 +19,22 @@ package org.apache.hawq.pxf.service.utilities;
  * under the License.
  */
 
+import java.io.IOException;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.hadoop.security.UserGroupInformation;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.apache.hadoop.hive.thrift.DelegationTokenIdentifier;
+import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.SecurityUtil;
+import org.apache.hadoop.security.token.Token;
+import org.apache.hadoop.security.UserGroupInformation;
+
+import org.apache.thrift.TException;
 
 /**
  * This class relies heavily on Hadoop API to
@@ -105,5 +114,38 @@ public class SecureLogin {
      */
     public static boolean isUserImpersonationEnabled() {
         return StringUtils.equalsIgnoreCase(System.getProperty(PROPERTY_KEY_USER_IMPERSONATION, ""), "true");
+    }
+
+
+    /**
+     * Returns delegation token for Metastore connection
+     * @param gpdbUser greenplum user
+     *
+     * @throws RuntimeException Thrown when authentication fails
+     */
+    public static Token<DelegationTokenIdentifier> getMetastoreToken(String gpdbUser) {
+        HiveMetaStoreClient tokenFetchingClient = null;
+        try {
+            UserGroupInformation.getLoginUser().checkTGTAndReloginFromKeytab();
+            tokenFetchingClient = new HiveMetaStoreClient(new HiveConf());
+            if (tokenFetchingClient == null) {
+                return null;
+            }
+            String delegationTokenString = tokenFetchingClient.getDelegationToken(gpdbUser, gpdbUser);
+            if (delegationTokenString == null) {
+                return null;
+            }
+            Token<DelegationTokenIdentifier> delegationToken = new Token<>();
+            delegationToken.decodeFromUrlString(delegationTokenString);
+            delegationToken.setService(new Text(gpdbUser));
+            return delegationToken;
+        } catch (TException | IOException te) {
+            LOG.error("Metastore delegation token creation error: " + te.getMessage());
+            throw new RuntimeException(te);
+        } finally {
+            if (tokenFetchingClient != null) {
+                tokenFetchingClient.close();
+            }
+        }
     }
 }


### PR DESCRIPTION
Add support for Kerberos authentication to PXF-Hive plugin.

`authenticate()` in `HiveUtilities` provides an interface to handle authentication. It also prevents repeated authentication attempts (`MetadataFetcher` is not the only place that requires authentication; it is also required by `HiveDataFragmenter`).