### PR TITLE
Fix Kerberos authentication for Hive

### DIFF
--- a/pxf/pxf-hive/src/main/java/org/apache/hawq/pxf/plugins/hive/HiveDataFragmenter.java
+++ b/pxf/pxf-hive/src/main/java/org/apache/hawq/pxf/plugins/hive/HiveDataFragmenter.java
@@ -19,9 +19,7 @@ package org.apache.hawq.pxf.plugins.hive;
  * under the License.
  */
 
-import java.io.ByteArrayOutputStream;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
@@ -53,7 +51,6 @@ import org.apache.hawq.pxf.api.Fragmenter;
 import org.apache.hawq.pxf.api.FragmentsStats;
 import org.apache.hawq.pxf.api.LogicalFilter;
 import org.apache.hawq.pxf.api.Metadata;
-import org.apache.hawq.pxf.api.io.DataType;
 import org.apache.hawq.pxf.api.utilities.ColumnDescriptor;
 import org.apache.hawq.pxf.api.utilities.InputData;
 import org.apache.hawq.pxf.api.utilities.ProfilesConf;
@@ -120,11 +117,11 @@ public class HiveDataFragmenter extends Fragmenter {
      */
     public HiveDataFragmenter(InputData inputData, Class<?> clazz) {
         super(inputData);
-        jobConf = new JobConf(new Configuration(), clazz);
-        client = HiveUtilities.initHiveClient();
+        jobConf = new JobConf(HiveUtilities.getHiveConf(new Configuration()), clazz);
+        client = HiveUtilities.initHiveClient(jobConf);
         // canPushDownIntegral represents hive.metastore.integral.jdo.pushdown property in hive-site.xml
         canPushDownIntegral =
-                HiveConf.getBoolVar(new HiveConf(), HiveConf.ConfVars.METASTORE_INTEGER_JDO_PUSHDOWN);
+                HiveConf.getBoolVar(jobConf, HiveConf.ConfVars.METASTORE_INTEGER_JDO_PUSHDOWN);
     }
 
     @Override
@@ -427,9 +424,9 @@ public class HiveDataFragmenter extends Fragmenter {
             return false;
         }
 
-        /* 
-         * HAWQ-1527 - Filtering only supported for partition columns of type string or 
-         * intgeral datatype. Integral datatypes include - TINYINT, SMALLINT, INT, BIGINT. 
+        /*
+         * HAWQ-1527 - Filtering only supported for partition columns of type string or
+         * intgeral datatype. Integral datatypes include - TINYINT, SMALLINT, INT, BIGINT.
          * Note that with integral data types only equals("=") and not equals("!=") operators
          * are supported. There are no operator restrictions with String.
          */

--- a/pxf/pxf-hive/src/main/java/org/apache/hawq/pxf/plugins/hive/HiveMetadataFetcher.java
+++ b/pxf/pxf-hive/src/main/java/org/apache/hawq/pxf/plugins/hive/HiveMetadataFetcher.java
@@ -8,9 +8,9 @@ package org.apache.hawq.pxf.plugins.hive;
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -62,8 +62,9 @@ public class HiveMetadataFetcher extends MetadataFetcher {
         super(md);
 
         // init hive metastore client connection.
-        client = HiveUtilities.initHiveClient();
         jobConf = new JobConf(new Configuration());
+        client = HiveUtilities.initHiveClient(jobConf);
+
     }
 
     /**

--- a/pxf/pxf-hive/src/test/java/org/apache/hawq/pxf/plugins/hive/HiveDataFragmenterTest.java
+++ b/pxf/pxf-hive/src/test/java/org/apache/hawq/pxf/plugins/hive/HiveDataFragmenterTest.java
@@ -8,9 +8,9 @@ package org.apache.hawq.pxf.plugins.hive;
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -49,7 +49,7 @@ import java.util.*;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({HiveDataFragmenter.class}) // Enables mocking 'new' calls
-@SuppressStaticInitializationFor({"org.apache.hadoop.mapred.JobConf", 
+@SuppressStaticInitializationFor({"org.apache.hadoop.mapred.JobConf",
                                   "org.apache.hadoop.hive.metastore.api.MetaException",
                                   "org.apache.hawq.pxf.plugins.hive.utilities.HiveUtilities"}) // Prevents static inits
 public class HiveDataFragmenterTest {
@@ -64,7 +64,7 @@ public class HiveDataFragmenterTest {
     public void construction() throws Exception {
         prepareConstruction();
         fragmenter = new HiveDataFragmenter(inputData);
-        PowerMockito.verifyNew(JobConf.class).withArguments(hadoopConfiguration, HiveDataFragmenter.class);
+        PowerMockito.verifyNew(JobConf.class).withArguments(hiveConfiguration, HiveDataFragmenter.class);
         PowerMockito.verifyNew(HiveMetaStoreClient.class).withArguments(hiveConfiguration);
     }
 
@@ -313,12 +313,12 @@ public class HiveDataFragmenterTest {
         PowerMockito.whenNew(Configuration.class).withNoArguments().thenReturn(hadoopConfiguration);
 
         jobConf = mock(JobConf.class);
-        PowerMockito.whenNew(JobConf.class).withArguments(hadoopConfiguration, HiveDataFragmenter.class).thenReturn(jobConf);
+        PowerMockito.whenNew(JobConf.class).withAnyArguments().thenReturn(jobConf);
 
         hiveConfiguration = mock(HiveConf.class);
-        PowerMockito.whenNew(HiveConf.class).withNoArguments().thenReturn(hiveConfiguration);
+        PowerMockito.whenNew(HiveConf.class).withAnyArguments().thenReturn(hiveConfiguration);
 
         hiveClient = mock(HiveMetaStoreClient.class);
-        PowerMockito.whenNew(HiveMetaStoreClient.class).withArguments(hiveConfiguration).thenReturn(hiveClient);
+        PowerMockito.whenNew(HiveMetaStoreClient.class).withAnyArguments().thenReturn(hiveClient);
     }
 }

--- a/pxf/pxf-hive/src/test/java/org/apache/hawq/pxf/plugins/hive/HiveMetadataFetcherTest.java
+++ b/pxf/pxf-hive/src/test/java/org/apache/hawq/pxf/plugins/hive/HiveMetadataFetcherTest.java
@@ -8,9 +8,9 @@ package org.apache.hawq.pxf.plugins.hive;
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -95,7 +95,7 @@ public class HiveMetadataFetcherTest {
             fetcher.getMetadata(tableName);
             fail("Expected an IllegalArgumentException");
         } catch (IllegalArgumentException ex) {
-            assertEquals("\"t.r.o.u.b.l.e.m.a.k.e.r\" is not a valid Hive table name. Should be either <table_name> or <db_name.table_name>", ex.getMessage()); 
+            assertEquals("\"t.r.o.u.b.l.e.m.a.k.e.r\" is not a valid Hive table name. Should be either <table_name> or <db_name.table_name>", ex.getMessage());
         }
     }
 
@@ -269,7 +269,7 @@ public class HiveMetadataFetcherTest {
 
     private void prepareConstruction() throws Exception {
         hiveConfiguration = mock(HiveConf.class);
-        PowerMockito.whenNew(HiveConf.class).withNoArguments().thenReturn(hiveConfiguration);
+        PowerMockito.whenNew(HiveConf.class).withAnyArguments().thenReturn(hiveConfiguration);
 
         hiveClient = mock(HiveMetaStoreClient.class);
         PowerMockito.whenNew(HiveMetaStoreClient.class).withArguments(hiveConfiguration).thenReturn(hiveClient);


### PR DESCRIPTION
This fixes AS-600709 (https://support.arenadata.io/scp/tickets.php?id=504).

Use Hadoop UserGroupInformation `doAs()` method to authenticate to Hive and get a delegation token for Hive metastore. This allows further operations with Hive kerberized.

For this solution to work, extra modifications are required:

* `yarn-site.xml` on each segment must be modifed, so that it includes the following:
```
<property>
      <name>yarn.resourcemanager.principal</name>
      <value><USER>/_HOST@<REALM></value>
</property>
```
where `<USER>` and `<REALM>` are set appropriately. It is possible to set `yarn.resourcemanager.principal` in some other configuration file that PXF Hive plugin uses to access Hive.

* Two libraries from Apache HttpComponents **HttpClient** (downloads at https://hc.apache.org/downloads.cgi) should be available to PXF and included in its classpath (`pxf-private.classpath`). Only the following two JARs are necessary:
    * `httpcore-*[0-9].jar`
    * `httpclient-*[0-9].jar`


This solution is tested on our GPDB + Hive cluster (Kerberized).